### PR TITLE
Avro converter

### DIFF
--- a/assets/spark_lsst_transfer.py
+++ b/assets/spark_lsst_transfer.py
@@ -530,10 +530,6 @@ def main(args):
         # other cases
         cnames = content
 
-        if "diaSource.midpointMjdTai" not in cnames:
-            # required for the Kafka client partitionment
-            cnames.append("diaSource.midpointMjdTai")
-
     # enforce proper serialisation
     cnames = sanitize_fields(cnames)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -53,9 +53,9 @@ docutils==0.21.2
 executing==2.1.0
 faust-cchardet==2.1.19
 fink-client==9.2
-fink-filters==7.24
+fink-filters==7.26
 fink-spins==0.3.8
-fink-utils==0.56.0
+fink-utils==0.57.0
 finufft==2.3.1
 Flask==3.0.3
 Flask-Compress==1.17
@@ -183,4 +183,4 @@ xyzservices==2024.9.0
 yarl==1.18.3
 zipp==3.21.0
 zstandard==0.23.0
-git+https://github.com/astrolabsoftware/fink-science@8.39.0
+git+https://github.com/astrolabsoftware/fink-science@8.40.0


### PR DESCRIPTION
Closes #71 

This PR updates the version of fink-utils to fix a bug in avro schema converter (https://github.com/astrolabsoftware/fink-utils/releases/tag/0.57.0). In addition, it removes the unnecessary addition of `diaSource.midpointMjdTai` column which could be in conflict with user-defined fields.