### PR TITLE
Docker/lsst portal dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,15 @@
+# Ignore certain folders and files to optimize the Docker image of fink-science-portal 
+
+# Files/folders that are unnecessary for the container
+.github/
+docker/
+cache/
+
+# test file
+run_tests.sh
+
+# temp files
+*.log
+*.pyc
+*.pyo
+__pycache__/

--- a/config.yml
+++ b/config.yml
@@ -1,3 +1,3 @@
-APIURL: http://localhost:24001
+APIURL: https://api.lsst.fink-portal.org/
 HOST: localhost
 PORT: 24000

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,47 @@
+# Copyright 2026 AstroLab Software
+# Author: Massinissa MACHTER (massinissa.machter@ijclab.in2p3.fr)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Multi stages 
+FROM python:3.11-slim AS builder 
+
+WORKDIR /app
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends build-essential git && \
+    rm -rf /var/lib/apt/lists/* 
+
+COPY requirements.txt . 
+
+RUN python -m venv /venv && \
+    /venv/bin/pip install --upgrade pip && \
+    /venv/bin/pip install -r requirements.txt
+
+FROM python:3.11-slim AS runtime 
+
+WORKDIR /lsst.fink-portal.org
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+     PYTHONUNBUFFERED=1 \
+     PATH="/venv/bin:$PATH"
+
+COPY --from=builder /venv /venv
+
+COPY . . 
+
+EXPOSE 24000 
+CMD ["python", "index.py"]

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,86 @@
+# Dockerfile lsst.fink-portal.org
+Here is the Docker tutorial to develop lsst.fink-portal.org container on your local machines.
+
+Make sure you have docker installed : https://docs.docker.com/get-docker/
+
+
+## Develop your Docker
+
+Fistly, you have to clone the lsst.fink-portal.org on the server in your local machine.
+
+```bash
+git clone https://github.com/astrolabsoftware/lsst.fink-portal.org
+```
+
+Enter in this new Directory.
+
+```bash
+cd lsst.fink-portal.org
+```
+
+## build your Docker image
+
+To build a docker image, you should use `sudo docker build -f <path/to/Dockerfile> -t <image name> <path destination of your image>`
+
+Therefore, we currently use :
+
+```bash
+sudo docker build -f docker/Dockerfile -t lsst-fink-portal .
+```
+Note that the . is the current directory. 
+Note also that the **image size** of lsst.fink-portal.org is highly optimized (see DockerFile)
+
+The default docker images will show all top level images, their repository and tags, and their size.
+
+```bash
+sudo docker images
+```
+
+
+
+## Run your docker
+
+This is the documentation in order to run a command in a new container.
+
+We set environment variables :
+```bash
+export HOST=0.0.0.0
+export PORT=8000   # Replace 8000 with your desired port
+```
+We can now run with :
+
+```bash
+docker run -d -p ${PORT}:${PORT} -e HOST=${HOST} -e PORT=${PORT} lsst-fink-portal:latest
+```
+
+The `docker ps` command only shows running containers by default. We can notice The ID of each containers. 
+
+```bash
+sudo docker ps
+```
+Once the container is running, you can visit the portal in your browser at: http://localhost:8000 
+
+
+
+If you have a problem during the running command, think to remove the `.bash_history` file.
+
+```bash
+ls -ltha
+```
+```bash
+sudo rm .bash_history
+```
+
+Enter `exit` to get out of the container.
+
+To stop and remove your container, type `sudo docker rm -f <id_of_container>`.
+
+
+
+### Additionnal Supports
+
+https://docs.docker.com/engine/reference/commandline/build/ 
+
+https://docs.docker.com/engine/reference/commandline/run/
+
+https://docs.docker.com/engine/reference/commandline/images/

--- a/index.py
+++ b/index.py
@@ -12,6 +12,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import os 
+
 import dash_bootstrap_components as dbc
 import dash_mantine_components as dmc
 import numpy as np
@@ -523,4 +525,8 @@ server.config["JSON_SORT_KEYS"] = False
 
 if __name__ == "__main__":
     config_args = extract_configuration("config.yml")
-    app.run(config_args["HOST"], debug=True, port=config_args["PORT"])
+
+    host = os.getenv("HOST",config_args["HOST"])
+    port = int(os.getenv("PORT",config_args["PORT"]))
+
+    app.run(host=host, debug=True, port=port)

--- a/index.py
+++ b/index.py
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import os 
+import os
 
 import dash_bootstrap_components as dbc
 import dash_mantine_components as dmc
@@ -191,25 +191,27 @@ plotly_color_sets = [
 ]
 
 
-component = dmc.Box([
-    dmc.Group(
-        [
-            dmc.Select(
-                id="color_scale",
-                value="Fink",
-                data=[{"value": k, "label": k} for k in plotly_color_sets],
-                w=110,
-                # mb=10,
-                persistence=True,
-                searchable=True,
-                clearable=True,
-                radius="xl",
-            ),
-            html.Div(id="color_palette"),
-        ],
-        justify="space-around",
-    ),
-])
+component = dmc.Box(
+    [
+        dmc.Group(
+            [
+                dmc.Select(
+                    id="color_scale",
+                    value="Fink",
+                    data=[{"value": k, "label": k} for k in plotly_color_sets],
+                    w=110,
+                    # mb=10,
+                    persistence=True,
+                    searchable=True,
+                    clearable=True,
+                    radius="xl",
+                ),
+                html.Div(id="color_palette"),
+            ],
+            justify="space-around",
+        ),
+    ]
+)
 
 # embedding the navigation bar
 app.layout = dmc.MantineProvider(
@@ -526,7 +528,7 @@ server.config["JSON_SORT_KEYS"] = False
 if __name__ == "__main__":
     config_args = extract_configuration("config.yml")
 
-    host = os.getenv("HOST",config_args["HOST"])
-    port = int(os.getenv("PORT",config_args["PORT"]))
+    host = os.getenv("HOST", config_args["HOST"])
+    port = int(os.getenv("PORT", config_args["PORT"]))
 
     app.run(host=host, debug=True, port=port)


### PR DESCRIPTION
## Adding a Docker project for lsst.fink-portal
I added **docker/** and **.dockerignore**, and I also modified two files:
- **index.py** : Explicitly read HOST and PORT from **environment variables** and
fallback to config.yml when not provided. This ensures the Dash
application binds to 0.0.0.0 inside Docker containers, allowing
external access through port mapping, because the new **Dash version** used in  lsst.fink-portal always defaults to localhost. 

- **config.yml** : change **APIURL** from http://localhost:24001 to https://api.lsst.fink-portal.org/
