### PR TITLE
[LC] Expose science/template/difference

### DIFF
--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -97,9 +97,6 @@ DEFAULT_FINK_MARKERS = {
     "y": "pentagon",  # Matplotlib 'p' -> Plotly 'pentagon'
 }
 
-default_radio_options = ["Total flux", "Difference flux", "Magnitude"]
-all_radio_options = {v: default_radio_options for v in default_radio_options}
-
 
 def generate_rgb_color_sequence(color_scale: str = "Fink", n_colors: int = 6):
     """Return a list of `n_colors` based on color_scale
@@ -720,7 +717,7 @@ def draw_lightcurve_preview(
     is_sso=False,
     color_scale="Fink",
     units="magnitude",
-    measurement="total",
+    measurement="science",
     switch_layout="plain",
     layout=None,
 ) -> dict:
@@ -731,14 +728,18 @@ def draw_lightcurve_preview(
     figure: dict
     """
     # shortcuts -- in microJansky
-    if measurement == "total":
+    if measurement == "science":
         flux_name = "r:scienceFlux"
         flux_err_name = "r:scienceFluxErr"
-        layout["yaxis"]["title"] = "Total flux (microJansky)"
-    elif measurement == "differential":
+        layout["yaxis"]["title"] = "Science PSF flux (microJansky)"
+    elif measurement == "template":
+        flux_name = "r:templateFlux"
+        flux_err_name = "r:templateFluxErr"
+        layout["yaxis"]["title"] = "Template PSF flux (microJansky)"
+    elif measurement == "difference":
         flux_name = "r:psfFlux"
         flux_err_name = "r:psfFluxErr"
-        layout["yaxis"]["title"] = "Difference flux (microJansky)"
+        layout["yaxis"]["title"] = "Difference PSF flux (microJansky)"
 
     # Get data if necessary
     if pdf is None and isinstance(main_id, str):
@@ -783,10 +784,12 @@ def draw_lightcurve_preview(
         # Using same names as others despite being magnitudes
         flux, flux_err = flux_to_mag(flux, flux_err)
         layout["yaxis"]["autorange"] = "reversed"
-        if measurement == "differential":
+        if measurement == "difference":
             layout["yaxis"]["title"] = "Difference magnitude"
+        elif measurement == "template":
+            layout["yaxis"]["title"] = "Template magnitude"
         else:
-            layout["yaxis"]["title"] = "Magnitude"
+            layout["yaxis"]["title"] = "Science magnitude"
 
     if units == "flux":
         # micro-jansky
@@ -1075,14 +1078,6 @@ def draw_lightcurve(
     switch_layout: str, object_data, object_ztf, color_scale, units, measurement
 ) -> dict:
     """Draw diaObject lightcurve with errorbars
-
-    Parameters
-    ----------
-    switch: int
-        Choose:
-          - 0 to display Total Flux
-          - 1 to display Difference Flux
-          - 2 to display Magnitude
 
     Returns
     -------

--- a/apps/utils.py
+++ b/apps/utils.py
@@ -106,9 +106,9 @@ def flux_to_mag(flux, flux_err):
     Parameters
     ----------
     flux: array-like
-        Total flux in nJy
+        Flux in nJy
     flux_err: array-like
-        Total flux error in nJy
+        Flux error in nJy
 
     Returns
     -------

--- a/index.py
+++ b/index.py
@@ -191,27 +191,25 @@ plotly_color_sets = [
 ]
 
 
-component = dmc.Box(
-    [
-        dmc.Group(
-            [
-                dmc.Select(
-                    id="color_scale",
-                    value="Fink",
-                    data=[{"value": k, "label": k} for k in plotly_color_sets],
-                    w=110,
-                    # mb=10,
-                    persistence=True,
-                    searchable=True,
-                    clearable=True,
-                    radius="xl",
-                ),
-                html.Div(id="color_palette"),
-            ],
-            justify="space-around",
-        ),
-    ]
-)
+component = dmc.Box([
+    dmc.Group(
+        [
+            dmc.Select(
+                id="color_scale",
+                value="Fink",
+                data=[{"value": k, "label": k} for k in plotly_color_sets],
+                w=110,
+                # mb=10,
+                persistence=True,
+                searchable=True,
+                clearable=True,
+                radius="xl",
+            ),
+            html.Div(id="color_palette"),
+        ],
+        justify="space-around",
+    ),
+])
 
 # embedding the navigation bar
 app.layout = dmc.MantineProvider(

--- a/index.py
+++ b/index.py
@@ -289,15 +289,19 @@ app.layout = dmc.MantineProvider(
                                                 dmc.Text("Measurement"),
                                                 dmc.Select(
                                                     id="select-measurement",
-                                                    value="total",
+                                                    value="science",
                                                     data=[
                                                         {
-                                                            "value": "total",
-                                                            "label": "total",
+                                                            "value": "science",
+                                                            "label": "science",
                                                         },
                                                         {
-                                                            "value": "differential",
-                                                            "label": "differential",
+                                                            "value": "template",
+                                                            "label": "template",
+                                                        },
+                                                        {
+                                                            "value": "difference",
+                                                            "label": "difference",
                                                         },
                                                     ],
                                                     w=200,

--- a/telemetry.py
+++ b/telemetry.py
@@ -18,9 +18,8 @@ import inspect
 import time
 from functools import wraps
 
-from dash import Dash, callback_context
-
 from colorama import Fore, Style
+from dash import Dash, callback_context
 
 LOG_CALLBACK_TELEMETRY = True
 


### PR DESCRIPTION
Closes #83 

This PR replace the old Total/differential options by science/template/difference on the right configuration widget -- which make more sense.

## Before

<img width="1624" height="861" alt="image" src="https://github.com/user-attachments/assets/0c672dff-8e62-4021-8aa4-837e66630a61" />

## After

<img width="1624" height="861" alt="portal_photometry_options" src="https://github.com/user-attachments/assets/548b0ac0-bdcb-44e8-bb92-32909a9fe5d3" />

Note that the y-axis label also changes.
