### PR TITLE
Fix: change min_cut and max_cut to vmin and vmax

### DIFF
--- a/apps/cards.py
+++ b/apps/cards.py
@@ -69,7 +69,6 @@ def card_search_result(row, i):
     # FIXME: should be a call to the tag resolver, with all tags printed here.
     cdsxmatch = row.get("f:xm_simbad_otype")
     if cdsxmatch not in BAD_VALUES and not pd.isna(cdsxmatch):
-        print(cdsxmatch, type(cdsxmatch))
         badges.append(
             make_badge(
                 f"SIMBAD: {cdsxmatch}",

--- a/apps/plotting.py
+++ b/apps/plotting.py
@@ -698,8 +698,8 @@ def _data_stretch(
         stretch=stretch,
         power=exponent,
         asinh_a=vmid,
-        min_cut=vmin,
-        max_cut=vmax,
+        vmin=vmin,
+        vmax=vmax,
         clip=False,
     )
 


### PR DESCRIPTION
Avoid deprecation warnings from Astropy>=6.1.X.
Reduces noise in logs and improve maintenance durability.
Closes #103.